### PR TITLE
Allow specifying a custom annealing termination condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ locations = [
 Next we need a way to calculate the total energy of traveling to each location in turn. Think of it as a representation of the efficiency of the trip; the further away one point is away from the next, the less efficient the trip is.
 
 ```ruby
-energy_calculator = -> (locations) do
+energy_calculator = lambda do |locations|
   locations.each_cons(2).sum do |location1, location2|
     location1.distance(location2)
   end
@@ -64,7 +64,7 @@ end
 Finally, we need a way to make small, random changes the order of the locations the salesperson will visit as we probe for the most efficient route.
 
 ```ruby
-state_change = -> (locations) do
+state_change = lambda do |locations|
   size = locations.size
   swapped = locations.dup
   idx_a = rand(size)
@@ -85,15 +85,14 @@ solution.state
 # => [(20,40), (40,120), (100,120), (60,200), (180,200)]
 ```
 
+### Using custom temperature and cooling settings
+
 If you want to iterate with other parameters you can send the parameters `temperature` and `cooling_rate`.
 
 ```ruby
 simulator = Annealing::Simulator.new(temperature: 10_000, cooling_rate: 0.5)
-solution = simulator.run(locations,
-                         energy_calculator: energy_calculator,
-                         state_change: state_change)
-solution.energy
-# => 351.901234
+solution = simulator.run(locations, energy_calculator: energy_calculator,
+                                    state_change: state_change)
 solution.state
 # => [(20,40), (40,120), (100,120), (60,200), (180,200)]
 ```
@@ -106,19 +105,8 @@ You can set default parameters that will be used in every simulation. For instan
 Annealing.configure do |c|
   c.temperature  = 10_000
   c.cooling_rate = 0.5
-  c.energy_calculator = -> (locations) do
-    locations.each_cons(2).sum do |location1, location2|
-      location1.distance(location2)
-    end
-  end
-  c.state_change = -> (locations) do
-    size = locations.size
-    swapped = locations.dup
-    idx_a = rand(size)
-    idx_b = rand(size)
-    swapped[idx_b], swapped[idx_a] = swapped[idx_a], swapped[idx_b]
-    swapped
-  end
+  c.energy_calculator = energy_calculator
+  c.state_change = state_change
 end
 
 solution = Annealing.simulate(locations)
@@ -159,16 +147,32 @@ simulator = Annealing::Simulator.new
 solution = simulator.run(locations, energy_calculator: calculator.method(:energy))
 ```
 
+### Setting a simulation termination condition
+
+Typically, annealing simulators are tasked with finding "close enough" solutions to complex problems by continuously comparing new permutations of an object against one other as the temperature slowly drops to 0 and then returning the lowest energy configuration it found. However, sometimes "close enough" can be determined by other factors as well. For this reason, you might specify a termination condition that will stop the annealing process as soon as the "good enough" condition is met regardless of the current temperature.
+
+Like `energy_calculator` and `state_change`, the `termination_condition` can be any object that responds to `#call` and it can be set globally or per simulation. It should accept three arguments: the current `state` of the object, the `energy` calculation of the current object, and the current `temperature` of the annealer.
+
+```ruby
+# Stop as soon as we find any 0-energy state
+termination_condition = lambda do |state, energy, temperature|
+  energy == 0
+end
+
+simulator = Annealing::Simulator.new
+solution = simulator.run(some_collection, termination_condition: termination_condition)
+solution.state
+```
+
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake` to run the test suite. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/3zcurdia/annealing. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/3zcurdia/annealing/blob/master/CODE_OF_CONDUCT.md).
-
 
 ## Code of Conduct
 

--- a/lib/annealing/configuration.rb
+++ b/lib/annealing/configuration.rb
@@ -4,7 +4,7 @@ module Annealing
   # It enables the gem configuration
   class Configuration
     attr_accessor :temperature, :cooling_rate, :logger,
-                  :energy_calculator, :state_change
+                  :energy_calculator, :state_change, :termination_condition
 
     def initialize
       reset
@@ -16,6 +16,7 @@ module Annealing
       @logger = Logger.new($stdout, level: Logger::INFO)
       @energy_calculator = nil
       @state_change = nil
+      @termination_condition = nil
     end
   end
 end

--- a/lib/annealing/simulator.rb
+++ b/lib/annealing/simulator.rb
@@ -14,12 +14,16 @@ module Annealing
       normalize_cooling_rate
     end
 
-    def run(initial_state, energy_calculator: nil, state_change: nil)
+    def run(initial_state, energy_calculator: nil, state_change: nil, termination_condition: nil)
+      termination_condition ||= default_termination_condition
+
       current = Metal.new(initial_state,
                           energy_calculator: energy_calculator,
                           state_change: state_change)
       Annealing.logger.debug("Original: #{current}")
       cool_down do |temp|
+        break if termination_condition_met?(termination_condition, current, temp)
+
         current = current.cooled(temp)
       end
       Annealing.logger.debug("Optimized: #{current}")
@@ -36,12 +40,22 @@ module Annealing
       @cooling_rate = -1.0 * cooling_rate if cooling_rate.positive?
     end
 
+    def termination_condition_met?(termination_condition, metal, temperature)
+      return false unless termination_condition.respond_to?(:call)
+
+      termination_condition.call(metal.state, metal.energy, temperature)
+    end
+
     def default_temperature
       Annealing.configuration.temperature
     end
 
     def default_cooling_rate
       Annealing.configuration.cooling_rate
+    end
+
+    def default_termination_condition
+      Annealing.configuration.termination_condition
     end
   end
 end

--- a/test/annealing/configuration_test.rb
+++ b/test/annealing/configuration_test.rb
@@ -29,5 +29,9 @@ module Annealing
     def test_does_not_set_a_default_state_change_function
       assert_nil @configuration.state_change
     end
+
+    def test_does_not_set_a_default_termination_condition
+      assert_nil @configuration.termination_condition
+    end
   end
 end

--- a/test/annealing/simulator_test.rb
+++ b/test/annealing/simulator_test.rb
@@ -6,50 +6,49 @@ module Annealing
   class SimulatorTest < Minitest::Test
     def setup
       @collection = (1..100).to_a.shuffle
+      @cooling_rate = 1
+      @temperature = 999
+      @total_iterations = @temperature / @cooling_rate
 
       Annealing.configure do |config|
-        config.energy_calculator = lambda do |collection|
-          collection.each_with_index.sum { |n, i| Math.exp(i) * n }
-        end
-        config.state_change = ->(collection) { collection.shuffle }
+        config.cooling_rate = @cooling_rate
+        config.energy_calculator = ->(_) { 42 }
+        config.state_change = ->(state) { state }
+        config.temperature = @temperature
+        config.termination_condition = nil
       end
+
+      @simulator = Annealing::Simulator.new
     end
 
     def test_forces_temperature_to_float
-      custom_temperature = 9_999
-      refute_kind_of Float, custom_temperature
-      simulator = Annealing::Simulator.new(temperature: custom_temperature)
-      assert_kind_of Float, simulator.temperature
+      refute_kind_of Float, @temperature
+      assert_equal @temperature.to_f, @simulator.temperature
+      assert_kind_of Float, @simulator.temperature
     end
 
-    def test_forces_cooling_rate_to_float
-      custom_cooling_rate = 1
-      refute_kind_of Float, custom_cooling_rate
-      simulator = Annealing::Simulator.new(cooling_rate: custom_cooling_rate)
-      assert_kind_of Float, simulator.cooling_rate
+    def test_forces_cooling_rate_to_negative_float
+      refute_kind_of Float, @cooling_rate
+      assert_equal @cooling_rate.to_f * -1, @simulator.cooling_rate
+      assert_kind_of Float, @simulator.cooling_rate
     end
 
     def test_raises_an_error_if_the_temperature_is_negative
       assert_raises(ArgumentError, 'Invalid initial temperature') do
-        Annealing::Simulator.new(temperature: -9_999)
+        Annealing::Simulator.new(temperature: @temperature * -1)
       end
     end
 
     def test_uses_the_global_energy_calculator_and_state_change_method
-      custom_temperature = 1000
-      custom_cooling_rate = 1
-      total_iterations = custom_temperature / custom_cooling_rate
       global_energy_calculator = MiniTest::Mock.new
       global_state_changer = MiniTest::Mock.new
-      (total_iterations + 1).times do
+      (@total_iterations + 1).times do
         global_energy_calculator.expect(:call, 42, [@collection])
         global_state_changer.expect(:call, @collection, [@collection])
       end
       global_energy_calculator.expect(:call, 42, [@collection])
 
       Annealing.configure do |config|
-        config.temperature = custom_temperature
-        config.cooling_rate = custom_cooling_rate
         config.energy_calculator = global_energy_calculator
         config.state_change = global_state_changer
       end
@@ -60,20 +59,15 @@ module Annealing
     end
 
     def test_can_override_the_global_energy_calculator_and_state_change_method
-      custom_temperature = 1000
-      custom_cooling_rate = 1
-      total_iterations = custom_temperature / custom_cooling_rate
       local_energy_calculator = MiniTest::Mock.new
       local_state_changer = MiniTest::Mock.new
-      (total_iterations + 1).times do
+      (@total_iterations + 1).times do
         local_energy_calculator.expect(:call, 42, [@collection])
         local_state_changer.expect(:call, @collection, [@collection])
       end
       local_energy_calculator.expect(:call, 42, [@collection])
 
       Annealing.configure do |config|
-        config.temperature = custom_temperature
-        config.cooling_rate = custom_cooling_rate
         config.energy_calculator = MiniTest::Mock.new
         config.state_change = MiniTest::Mock.new
       end
@@ -83,6 +77,60 @@ module Annealing
                                    state_change: local_state_changer)
       local_energy_calculator.verify
       local_state_changer.verify
+    end
+
+    def test_uses_the_global_termination_condition_function_if_set
+      global_termination_condition = MiniTest::Mock.new
+      (@total_iterations + 1).times do |i|
+        current_temp = @temperature - (@cooling_rate * i)
+        global_termination_condition.expect(:call, false,
+                                            [@collection, 42, current_temp])
+      end
+
+      Annealing.configure do |config|
+        config.termination_condition = global_termination_condition
+      end
+
+      Annealing::Simulator.new.run(@collection)
+      global_termination_condition.verify
+    end
+
+    def test_can_override_the_global_termination_condition
+      local_termination_condition = MiniTest::Mock.new
+      (@total_iterations + 1).times do |i|
+        current_temp = @temperature - (@cooling_rate * i)
+        local_termination_condition.expect(:call, false,
+                                           [@collection, 42, current_temp])
+      end
+
+      Annealing.configure do |config|
+        config.termination_condition = MiniTest::Mock.new
+      end
+
+      simulator = Annealing::Simulator.new
+      simulator.run(@collection,
+                    termination_condition: local_termination_condition)
+      local_termination_condition.verify
+    end
+
+    def test_returns_early_if_termination_condition_is_met
+      global_energy_calculator = MiniTest::Mock.new
+      @total_iterations = 1 # We'll exit after the temp drops 1 step
+      (@total_iterations + 1).times do
+        global_energy_calculator.expect(:call, 42, [@collection])
+      end
+
+      global_termination_condition = lambda do |_state, _energy, temp|
+        temp == @temperature - 1
+      end
+
+      Annealing.configure do |config|
+        config.energy_calculator = global_energy_calculator
+        config.termination_condition = global_termination_condition
+      end
+
+      Annealing::Simulator.new.run(@collection)
+      global_energy_calculator.verify
     end
   end
 end


### PR DESCRIPTION
## What

Implements the second proposed change in #1

## Why

The simulated annealing algorithm definition typically provides for the ability to specify some condition that will halt the annealing process other than the temperature reaching 0. This could be a "good enough" energy threshold, a temperature other than 0, or some other arbitrary condition. Right now `Simulator#run` will continue until the temperature reaches 0 and then return whatever state it had settled on. It would be beneficial to be able to specify a function that receives the current `metal` and `temperature`, and returns a boolean result as to whether to continue annealing. In my case, for example, the first state that has an energy cost of 0, including the initial state, is considered "good enough" and there's no need to continue annealing.

## How

- adds a `termination_condition` config and runtime option
- cleans up the docs a bit

## TODO

This PR is a stacked on top of https://github.com/3zcurdia/annealing_rb/pull/4. Will need to re-open this targeting the upstream master once those PRs merge.